### PR TITLE
Added additional features

### DIFF
--- a/dap-extension/package.json
+++ b/dap-extension/package.json
@@ -9,9 +9,20 @@
   "categories": [
     "Debuggers"
   ],
-  "activationEvents": [ "onDebug", "onDebugResolve:dap-extension" ],
+  "activationEvents": [ "onDebug", "onDebugResolve:dap-extension", "onDebug:closures" ],
   "main": "./out/extension.js",
   "contributes": {
+    "views": {
+      "debug": [
+        { "id": "closures"
+        , "name": "closures"
+        , "visibility": "visible"
+        , "initialSize": 30
+        , "contextualTitle": "Closures for ${workspaceFolder}"
+        , "type": "tree"
+        }
+      ]
+    },
     "debuggers": [
       {
         "type": "dap-extension",

--- a/dap-extension/src/extension.ts
+++ b/dap-extension/src/extension.ts
@@ -13,6 +13,7 @@ import { ProviderResult } from 'vscode';
 // Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
 
+//    vscode.debug.onDidReceiveDebugSessionCustomEvent
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
 	console.log('Congratulations, your extension "external-stg-debugger" is now active!');

--- a/dap/dap.cabal
+++ b/dap/dap.cabal
@@ -35,6 +35,7 @@ executable dap
     , network
     , unagi-chan
     , unordered-containers
+    , string-conversions
     , aeson
     , text
     , time

--- a/dap/shell.nix
+++ b/dap/shell.nix
@@ -7,7 +7,7 @@ dap.env.overrideAttrs (drv: {
   shellHook = ''
      export PATH=$PATH:${pkgs.haskell.packages.ghc924.stack}/bin
      function ghcid () {
-        ${ghcid}/bin/ghcid --poll --allow-eval -c 'cabal repl'
+        ${ghcid}/bin/ghcid --poll --allow-eval -c 'cabal repl exe:dap'
      }
    '';
  })

--- a/dap/src/DAP/Server.hs
+++ b/dap/src/DAP/Server.hs
@@ -42,8 +42,7 @@ import           Network.Simple.TCP         ( serve, HostPreference(Host) )
 import           Network.Socket             ( socketToHandle, withSocketsDo, SockAddr, Socket )
 import           System.IO                  ( hClose, hSetNewlineMode, Handle, Newline(CRLF)
                                             , NewlineMode(NewlineMode, outputNL, inputNL)
-                                            , IOMode(ReadWriteMode)
-                                            )
+                                            , IOMode(ReadWriteMode) )
 import           System.IO.Error            ( isEOFError )
 import           Text.Read                  ( readMaybe )
 import qualified Data.ByteString.Lazy.Char8 as BL8
@@ -95,7 +94,7 @@ initAdaptorState handle address appStore serverConfig request = do
     , payload = []
     , ..
     }
-
+----------------------------------------------------------------------------
 -- | Updates sequence number, puts the new request into the AdaptorState
 --
 updateAdaptorState
@@ -106,7 +105,6 @@ updateAdaptorState state request = do
   state { request = request
         , seqRef = requestSeqNum request
         }
-
 ----------------------------------------------------------------------------
 -- | Communication loop between editor and adaptor
 -- Evaluates the current 'Request' located in the 'AdaptorState'


### PR DESCRIPTION
  - Closure view (skeleton)
  - Added `string-conversions` convenience package
  - `ServerConfig` logging now respected by `Server.hs`
  - Event sequence numbers ignored by default (from `vscode-mock-debug`)
  - Modified path names (now shows `Module.cmm`, `Module.stg`, etc.)
  - Pretty printing functions for `Atoms` and `Local` arguments.
  - Added C sources (added `isCSource`), this displays sources from `c-sources`.
  - Fixed bug related to `Step` command (use 'sendAndWait').
  - Added case for `ThreadFinishedMain`