### PR TITLE
Added black box integration tests for DAP server.

### DIFF
--- a/dap/.ghci
+++ b/dap/.ghci
@@ -1,2 +1,2 @@
-:set -isrc:exe
+:set -isrc:exe:test
 :set -XOverloadedStrings

--- a/dap/dap.cabal
+++ b/dap/dap.cabal
@@ -16,7 +16,7 @@ cabal-version:      >= 1.10
 extra-source-files:
   CHANGELOG.md
 
-executable dap
+executable dap-estg
   main-is:
     Main.hs
   ghc-options:
@@ -76,5 +76,43 @@ library
     , unordered-containers
   hs-source-dirs:
     src
+  default-language:
+    Haskell2010
+
+test-suite tests
+  type:
+    exitcode-stdio-1.0
+  hs-source-dirs:
+    test, src
+  main-is:
+    Main.hs
+  other-modules:
+    DAP.Response
+    DAP.Internal
+    DAP.Server
+    DAP.Adaptor
+    DAP.Server
+    DAP.Types
+    DAP.Event
+    DAP.Utils
+  build-depends:
+      aeson
+    , aeson-pretty
+    , async
+    , base < 5
+    , bytestring
+    , containers
+    , lifted-base
+    , monad-control
+    , hspec
+    , mtl
+    , network
+    , network-simple
+    , stm
+    , string-conversions
+    , text
+    , time
+    , transformers-base
+    , unordered-containers
   default-language:
     Haskell2010

--- a/dap/src/DAP/Types.hs
+++ b/dap/src/DAP/Types.hs
@@ -282,9 +282,6 @@ data AdaptorState app
     -- ^ Configuration information for the ServerConfig
     -- Identical across all debugging sessions
     --
-  , seqRef              :: !Seq
-    -- ^ Thread local sequence number, updating as responses and events are set
-    --
   , handle              :: Handle
     -- ^ Connection Handle
     --

--- a/dap/test/Main.hs
+++ b/dap/test/Main.hs
@@ -1,0 +1,184 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Main
+-- Copyright   :  (C) 2023 David M. Johnson
+-- License     :  BSD3-style (see the file LICENSE)
+-- Maintainer  :  David M. Johnson <djohnson.m@gmail.com>
+-- Stability   :  experimental
+-- Portability :  non-portable
+----------------------------------------------------------------------------
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings   #-}
+----------------------------------------------------------------------------
+module Main
+  ( main
+  ) where
+----------------------------------------------------------------------------
+import           Control.Monad
+import           Control.Concurrent
+import qualified Data.HashMap.Strict        as H
+import           Data.Aeson.Encode.Pretty
+import           Data.Aeson.Types
+import           Data.Aeson
+import           Data.Aeson.KeyMap
+import           Control.Concurrent.Async
+import           Control.Concurrent
+import           Control.Exception
+import qualified Data.ByteString.Lazy.Char8 as BL8 ( hPutStrLn )
+import           Network.Socket
+import           System.IO
+import           Data.String.Conversions
+import           Test.Hspec
+----------------------------------------------------------------------------
+import           DAP.Utils                  hiding (send)
+import           DAP.Internal
+import           DAP.Types
+import           DAP.Event
+import           DAP.Server
+import           DAP.Response
+----------------------------------------------------------------------------
+main :: IO ()
+main = withServer $
+  hspec $ do
+    describe "Should connect to the mock DAP server from a client" $ do
+
+      it "Should increment sequence number properly" $ do
+        withNewClient $ \handle -> do
+          send handle
+            [ "command" .= ("initialize" :: String)
+            , "seq"     .= (1 :: Int)
+            , "type"    .= ("request" :: String)
+            ]
+          shouldReceive handle
+            [ "seq"         .= (2 :: Int)
+            , "request_seq" .= (1 :: Int)
+            ]
+
+      it "Should connect / disconnect 100 clients" $ do
+        replicateM_ 100 $
+          withNewClient $ \handle -> do
+            send handle
+              [ "command" .= ("initialize" :: String)
+              , "seq"     .= (1 :: Int)
+              , "type"    .= ("request" :: String)
+              ]
+            shouldReceive handle
+              [ "seq"         .= (2 :: Int)
+              , "request_seq" .= (1 :: Int)
+              ]
+
+      it "Should perform req/resp. for initialize and receive initialized event" $ do
+          withNewClient $ \handle -> do
+            send handle
+              [ "command" .= ("initialize" :: String)
+              , "seq"     .= (1 :: Int)
+              , "type"    .= ("request" :: String)
+              ]
+            shouldReceive handle
+              [ "seq"         .= (2 :: Int)
+              , "request_seq" .= (1 :: Int)
+              , "command"     .= ("initialize" :: String)
+              , "type"        .= ("response" :: String)
+              ]
+            shouldReceive handle
+              [ "type"     .= ("event" :: String)
+              , "event"    .= ("initialized" :: String)
+              ]
+
+      it "Should receive configuration done and stop event" $ do
+          withNewClient $ \handle -> do
+            send handle
+              [ "command" .= ("configurationDone" :: String)
+              , "seq"     .= (100 :: Int)
+              , "type"    .= ("request" :: String)
+              ]
+            shouldReceive handle
+              [ "seq"         .= (101 :: Int)
+              , "request_seq" .= (100 :: Int)
+              , "command"     .= ("configurationDone" :: String)
+              , "type"        .= ("response" :: String)
+              ]
+            shouldReceive handle
+              [ "type"     .= ("event" :: String)
+              , "event"    .= ("stopped" :: String)
+              ]
+
+-- | Mock server communication, used in test runner
+--
+mockServerTalk
+  :: Command
+  -> Adaptor app ()
+mockServerTalk CommandInitialize = do
+  sendInitializeResponse
+  sendInitializedEvent
+mockServerTalk CommandConfigurationDone = do
+  sendConfigurationDoneResponse
+  sendStoppedEvent defaultStoppedEvent
+
+-- | Sample port shared amongst client and server
+--
+testPort :: Int
+testPort = 8001
+
+-- | Runs server in a thread, 'withAsync' ensures cleanup.
+--
+withServer :: IO () -> IO ()
+withServer test = withAsync server (const test)
+  where
+    server = runDAPServer config mockServerTalk
+    config = ServerConfig
+      { host = "localhost"
+      , port = testPort
+      , serverCapabilities = defaultCapabilities
+      , debugLogging = False
+      }
+
+-- | Spawns a new mock client that connects to the mock server.
+--
+withNewClient :: (Handle -> IO ()) -> IO ()
+withNewClient continue = withSocketsDo $ do
+  [info] <- getAddrInfo (Just addrInfo) Nothing (Just (show testPort))
+  socket <- openSocket info
+  connect socket (addrAddress info) `catch` exceptionHandler
+  handle <- socketToHandle socket ReadWriteMode
+  hSetNewlineMode handle NewlineMode { inputNL = CRLF, outputNL = CRLF }
+  continue handle `finally` hClose handle
+    where
+      exceptionHandler :: SomeException -> IO ()
+      exceptionHandler _ = do
+        threadDelay 100
+        putStrLn "Retrying connection..."
+        withNewClient continue
+
+      addrInfo :: AddrInfo
+      addrInfo
+        = defaultHints
+        { addrSocketType = Stream
+        , addrFamily = AF_INET
+        }
+
+-- | Helper to send JSON payloads to the server
+--
+send :: Handle -> [Pair] -> IO ()
+send handle message
+  = BL8.hPutStrLn handle
+  $ cs (encodeBaseProtocolMessage (object message))
+
+-- | Helper to receive JSON payloads to the client
+-- checks if 'Handle' returns a subset expected payload
+--
+shouldReceive
+  :: Handle
+  -- ^ Handle to receive bytes from
+  -> [Pair]
+  -- ^ Subset of JSON values that should be present in the payload
+  -> IO ()
+shouldReceive h expected = do
+  let Object ex = object expected
+  readPayload h >>= \case
+    Left e -> fail e
+    Right actual
+      | toHashMapText ex `H.isSubmapOf` toHashMapText actual -> pure ()
+      | otherwise -> encodePretty actual `shouldBe` encodePretty ex


### PR DESCRIPTION
 - Created a test-suite executable that mocks client / server communication. This is basically an implementation of `vscode-mock-debug`, except without a mock runtime. This helped to uncover the `seqNum` bug (fix also in this MR).

 - Removed 'seqRef'. Client / server communication (seems to be) always synchronous, events (seem to) not account for 'seqNum', and only a single response is permitted per request. Therefore, we can always use the 'seqNum' on the request in the response, incremented by one.

 - Fixed a bug where the 'requestSeqNum' was being used as the 'seqNum'.

 - Made all printing subject to a logging 'Bool' value. This ensures that test output is not interleaved with server output (since the tests run the server in a forked thread), but set 'debugLogging' to 'False'.

 - Added a helper function 'readPayload' for use in tests.

 - Re-added 'resetAdaptorStatePayload'. This is necessary for the new OutputEvent sink, otherwise it might send extra JSON from the parent thread it was forked from.

 - Added some tests for sequence numbers, events and some client connection load testing.
 
 ```
 Should connect to the mock DAP server from a client
  Should increment sequence number properly [✔]
  Should connect / disconnect 1000 clients [✔]
  Should perform req/resp. for initialize and receive initialized event [✔]
  Should receive configuration done and stop event [✔]

Finished in 2.4496 seconds
4 examples, 0 failures
```