### PR TITLE
Add CI, nix, incorporate GHC updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,10 @@ jobs:
     if: github.ref != 'refs/heads/master'
     steps:
      - uses: DeterminateSystems/nix-installer-action@main
+     - uses: actions/checkout@v3.5.3
+     - uses: cachix/install-nix-action@v25
+       with:
+         nix_path: nixpkgs=channel:nixpkgs-unstable
 
      - name: Nix channel update
        run: nix-channel --update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,6 @@ jobs:
      - name: Cabal update
        run: cabal update
 
-     - name: Install ghc, bzip2 and zlib as build-time dependencies
-       run: nix-env -iA pkgs.ghc pkgs.bzip2.dev pkgs.zlib.dev pkgs.zstd.dev -f .
-
      - name: (x86 - C++) Build ext-stg-gc (souffle-produced reachability analysis for GC)
        run: nix-build -A ext-stg-gc
 
@@ -35,5 +32,5 @@ jobs:
        run: nix-build -A dap-estgi-server
 
      - name: (x86 - GHC 9.6.6) Build dap-estgi-server w/ cabal
-       run: cabal build dap-estgi-server
+       run:  nix-shell -p pkgs.ghc -p pkgs.bzip2.dev -p pkgs.zlib.dev --run 'cabal build dap-estgi-server' -I=.
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+name: Haskell Debugger CI
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master'
+    steps:
+     - uses: DeterminateSystems/nix-installer-action@main
+
+     - name: Nix channel update
+       run: nix-channel --update
+
+     - name: Cabal install
+       run: nix-env -iA cabal-install -f .
+
+     - name: Cabal update
+       run: cabal update
+
+     - name: Install ghc, bzip2 and zlib as build-time dependencies
+       run: nix-env -iA pkgs.ghc pkgs.bzip2.dev pkgs.zlib.dev -f .
+
+     - name: (x86 - C++) Build ext-stg-gc (souffle-produced reachability analysis for GC)
+       run: nix-build -A ext-stg-gc
+
+     - name: (x86 - GHC 9.6.6) Build dap-estgi-server w/ cabal
+       run: cabal build dap-estgi-server
+
+     - name: (x86 - GHC 9.6.6) Build dap-estgi-server w/ nix
+       run: nix-build -A dap-estgi-server

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
        run: cabal update
 
      - name: Install ghc, bzip2 and zlib as build-time dependencies
-       run: nix-env -iA pkgs.ghc pkgs.bzip2.dev pkgs.zlib.dev -f .
+       run: nix-env -iA pkgs.ghc pkgs.bzip2.dev pkgs.zlib.dev pkgs.zstd.dev -f .
 
      - name: (x86 - C++) Build ext-stg-gc (souffle-produced reachability analysis for GC)
        run: nix-build -A ext-stg-gc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
        run: nix-channel --update
 
      - name: Cabal install
-       run: nix-env -iA cabal-install -f .
+       run: nix-env -iA pkgs.cabal-install -f .
 
      - name: Cabal update
        run: cabal update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,5 @@ jobs:
      - name: (x86 - GHC 9.6.6) Build dap-estgi-server w/ nix
        run: nix-build -A dap-estgi-server
 
-     - name: (x86 - GHC 9.6.6) Build dap-estgi-server w/ cabal
-       run:  nix-shell -p pkgs.ghc -p pkgs.bzip2.dev -p pkgs.zlib.dev --run 'cabal build dap-estgi-server' -I=.
-
+     # - name: (x86 - GHC 9.6.6) Build dap-estgi-server w/ cabal
+     #   run:  nix-shell -p pkgs.ghc -p pkgs.bzip2.dev -p pkgs.zlib.dev --run 'cabal build dap-estgi-server' -I=.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,9 @@ jobs:
      - name: (x86 - C++) Build ext-stg-gc (souffle-produced reachability analysis for GC)
        run: nix-build -A ext-stg-gc
 
+     - name: (x86 - GHC 9.6.6) Build dap-estgi-server w/ nix
+       run: nix-build -A dap-estgi-server
+
      - name: (x86 - GHC 9.6.6) Build dap-estgi-server w/ cabal
        run: cabal build dap-estgi-server
 
-     - name: (x86 - GHC 9.6.6) Build dap-estgi-server w/ nix
-       run: nix-build -A dap-estgi-server

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Haskell ESTGi Debugger
+# Haskell ESTGi Debugger ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/haskell-debugger/haskell-estgi-debugger/main.yml?style=flat-square)
+
 
 # Table of Contents
 1. [Introduction](#introduction)

--- a/cabal.project
+++ b/cabal.project
@@ -14,12 +14,12 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/TeofilC/digest
-  tag: ac9616b94cb8c4a9e07188d19979a6225ebd5a10
+  tag: 27ffb6396ef322c5185bc919cae563ac449ba235
 
 source-repository-package
   type: git
   location: https://github.com/haskell-debugger/dap
-  tag: 56d44d27c0cc509fc3e8198de448dbb2e9a6380f
+  tag: 99543ed
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -36,4 +36,7 @@ package external-stg-interpreter
 package external-stg-compiler
   flags: +external-ext-stg-liveness
 
+package digest
+  flags: -pkg-config
+
 allow-newer: type-errors-pretty:base

--- a/cabal.project
+++ b/cabal.project
@@ -1,34 +1,39 @@
-packages: dap-estgi-server
+packages:
+  dap-estgi-server
+
+source-repository-package
+  type: git
+  location: https://github.com/david-christiansen/final-pretty-printer
+  tag: 048e8fa2d8b2b7a6f9e4e209db4f67361321eec8
+
+source-repository-package
+  type: git
+  location: https://github.com/luc-tielen/souffle-haskell
+  tag: 268a11283ca9293b5eacabf7a0b79d9368232478
+
+source-repository-package
+  type: git
+  location: https://github.com/TeofilC/digest
+  tag: ac9616b94cb8c4a9e07188d19979a6225ebd5a10
+
+source-repository-package
+  type: git
+  location: https://github.com/haskell-debugger/dap
+  tag: 56d44d27c0cc509fc3e8198de448dbb2e9a6380f
 
 source-repository-package
     type: git
-    location: https://github.com/TeofilC/digest
-    tag: ac9616b94cb8c4a9e07188d19979a6225ebd5a10
-
-source-repository-package
-    type: git
-    location: https://github.com/haskell-debugger/dap
-    tag: 3784cc0e703cbe300d4e4874328b8b8dd998ea5f
-
-source-repository-package
-    type: git
-    location: https://github.com/grin-compiler/ghc-whole-program-compiler-project
-    tag: 80e408ebdeaf5c1cea72bfbf86823c32d4fdafbe
+    location: https://github.com/haskell-debugger/ghc-whole-program-compiler-project
+    tag: d058105b0bee1ab2e7c7aefd36bf9e0be6e840b7
     subdir:
       external-stg
       external-stg-syntax
       external-stg-interpreter
 
-source-repository-package
-    type: git
-    location: https://github.com/luc-tielen/souffle-haskell
-    tag: f8c9fc45eed709110af3d3301393f63f4535c71e
+package external-stg-interpreter
+  flags: +external-ext-stg-gc
 
-constraints:
-  type-errors-pretty == 0.0.1.2,
-  souffle-haskell == 3.4.0
-
-package digest
-  flags: -pkg-config
+package external-stg-compiler
+  flags: +external-ext-stg-liveness
 
 allow-newer: type-errors-pretty:base

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,106 @@
+with (builtins.fromJSON (builtins.readFile ./nixpkgs.json));
+
+{ nixpkgs ? builtins.fetchTarball {
+     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+    inherit sha256;
+  }
+}:
+
+let
+  # all the nix things
+  pkgs = import nixpkgs {};
+  sources = builtins.fromJSON (builtins.readFile ./source.json);
+
+  ghc-wpo-src =
+    pkgs.fetchFromGitHub sources.ghc-whole-program-compiler-project;
+
+  # this is the reachability analysis binary (cretaed by souffle) that runs
+  # the mark n' sweep GC pass. This is call by the external-stg-intepreter.
+  ext-stg-gc =
+    pkgs.stdenv.mkDerivation {
+      name = "ext-stg-gc";
+      src = "${ghc-wpo-src}/external-stg-interpreter";
+      buildInputs = with pkgs; [ souffle openmpi ];
+      buildPhase = ''
+        mkdir -pv $out/bin
+        g++ -fopenmp $src/datalog/ext-stg-gc.cpp \
+           -D_OPENMP -std=c++17 \
+           -o $out/bin/ext-stg-gc
+      '';
+    };
+
+  overrides = self: super: with pkgs.haskell.lib; {
+
+    type-errors-pretty = dontCheck (
+      doJailbreak (
+        self.callCabal2nix
+          "type-errors-pretty"
+          (pkgs.fetchFromGitHub sources.type-errors-pretty)
+          {}
+      )
+    );
+
+    digest =
+      self.callCabal2nix
+        "digest"
+        (pkgs.fetchFromGitHub sources.digest)
+        {};
+
+    final-pretty-printer = doJailbreak (
+      self.callCabal2nix
+        "final-pretty-printer"
+        (pkgs.fetchFromGitHub sources.final-pretty-printer)
+        {}
+    );
+
+    dap = doJailbreak (
+      self.callCabal2nix
+        "dap"
+        (pkgs.fetchFromGitHub sources.dap)
+        {}
+    );
+
+    dap-estgi-server =
+      self.callCabal2nix
+        "dap-estgi-server"
+        ./dap-estgi-server
+        {};
+
+    external-stg =
+      self.callCabal2nix
+        "external-stg"
+        "${ghc-wpo-src}/external-stg"
+        {};
+
+    external-stg-syntax =
+      self.callCabal2nix
+        "external-stg-syntax"
+        "${ghc-wpo-src}/external-stg-syntax"
+        {};
+
+    external-stg-interpreter =
+      self.callCabal2nixWithOptions
+        "external-stg-interpreter"
+        "${ghc-wpo-src}/external-stg-interpreter"
+        "-fexternal-ext-stg-gc"
+        {};
+
+    souffle-haskell =
+      dontCheck
+        (doJailbreak
+          (self.callCabal2nix "souffle-haskell"
+            (pkgs.fetchFromGitHub sources.souffle-haskell) {}
+          ));
+  };
+
+  hPkgs =
+    pkgs.haskellPackages.override { inherit overrides; };
+
+in
+
+# this is the set we export for CI, and for shell.nix
+{
+  inherit (hPkgs) dap-estgi-server;
+  inherit ext-stg-gc;
+  inherit pkgs;
+}

--- a/default.nix
+++ b/default.nix
@@ -24,7 +24,8 @@ let
       buildPhase = ''
         mkdir -pv $out/bin
         g++ -fopenmp $src/datalog/ext-stg-gc.cpp \
-           -D_OPENMP -std=c++17 \
+           -Wl,-u,__factory_Sf_ext_stg_gc_instance \
+           -std=c++17 \
            -o $out/bin/ext-stg-gc
       '';
     };

--- a/nixpkgs.json
+++ b/nixpkgs.json
@@ -1,0 +1,4 @@
+{
+  "rev" : "88e992074d86",
+  "sha256" : "sha256:1k5iv13faiyar5bsfw5klaz898662kcfyn85w5jrl2qkavf6y0y7"
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./default.nix {}).dap-estgi-server.env

--- a/source.json
+++ b/source.json
@@ -1,0 +1,47 @@
+{
+  "dap": {
+    "fetchSubmodules": true,
+    "leaveDotGit": false,
+    "owner": "haskell-debugger",
+    "repo": "dap",
+    "rev": "56d44d27c0cc509fc3e8198de448dbb2e9a6380f",
+    "sha256": "sha256-/FKfSyYJuzXqyBu/yFTlVBQYJ4SXgLGDzQ5xAdXajCE="
+  },
+  "digest": {
+    "fetchSubmodules": true,
+    "leaveDotGit": false,
+    "owner": "TeofilC",
+    "repo": "digest",
+    "rev": "ac9616b94cb8c4a9e07188d19979a6225ebd5a10",
+    "sha256": "sha256-2n2SV4GYAwd09QfWynlxgeCrsj49UI3He6X66ynqfSA="
+  },
+  "final-pretty-printer": {
+    "fetchSubmodules": true,
+    "leaveDotGit": false,
+    "owner": "david-christiansen",
+    "repo": "final-pretty-printer",
+    "rev": "048e8fa2d8b2b7a6f9e4e209db4f67361321eec8",
+    "sha256": "0d5ya1n85qgs59p2wlx501qa1nrlk7y20riydfknfqkr0fswcpnf"
+  },
+  "ghc-whole-program-compiler-project": {
+    "fetchSubmodules": true,
+    "leaveDotGit": false,
+    "owner": "dmjio",
+    "repo": "ghc-whole-program-compiler-project",
+    "rev": "d058105b0bee1ab2e7c7aefd36bf9e0be6e840b7",
+    "sha256": "sha256-lNNZRaJwHVPRi59pXEsWzxGrOJqwiAR2g56khKq8bic="
+  },
+  "souffle-haskell" : {
+    "owner" : "luc-tielen",
+    "repo" : "souffle-haskell",
+    "rev" : "268a11283ca9293b5eacabf7a0b79d9368232478",
+    "hash" : "sha256-n8qqNmrDNxLlM7FRfa1Da58jGCNWjBp9+B/yV3U98gg="
+  },
+  "type-errors-pretty": {
+    "fetchSubmodules": false,
+    "owner": "kowainik",
+    "repo": "type-errors-pretty",
+    "rev": "c85d6d0a7bf2278ddb03abddb5782a5b6095d343",
+    "sha256": "1yylw5c8ffzybcv7cm6ff0k88an4iz0fhc59md09s9zlns03f3d0"
+  }
+}

--- a/source.json
+++ b/source.json
@@ -26,10 +26,10 @@
   "ghc-whole-program-compiler-project": {
     "fetchSubmodules": true,
     "leaveDotGit": false,
-    "owner": "dmjio",
+    "owner": "haskell-debugger",
     "repo": "ghc-whole-program-compiler-project",
-    "rev": "d058105b0bee1ab2e7c7aefd36bf9e0be6e840b7",
-    "sha256": "sha256-lNNZRaJwHVPRi59pXEsWzxGrOJqwiAR2g56khKq8bic="
+    "rev": "65ecaed",
+    "sha256": "sha256-T9dUWUrGeva8ghwQ5Pu1paBbBgyjoTp3SQreHs94WRQ="
   },
   "souffle-haskell" : {
     "owner" : "luc-tielen",


### PR DESCRIPTION
In lieu of the dap updates #22 , and [ghc-whole-program-compiler project updates (to GHC-9.6.6+)](https://github.com/grin-compiler/ghc-whole-program-compiler-project/pull/13), we should now be able to test the haskell-debugger with our new dap changes. This is the second PR in a set to upgrade and abstract some facilities for preparing a dap release.

- Put project under CI (for both cabal and nix)
- Introduce a nixpkgs infra w/ pinning
- Add builds for the souffle static analysis C++ code (will make available during runtime for `dap-estgi-server`)
- Use `souffle-4.0`
- Github actions CI status badge to README.md

This PR includes the updates seen in https://github.com/grin-compiler/ghc-whole-program-compiler-project/pull/13 to prepare for #22. I have moved my fork of `ghc-whole-program-compiler` to this github org (@haskell-debugger) and this PR now uses that fork.

We should now be able to build (and soon test) #22 in CI on this repo by altering `source.json` and `cabal.project` to point to the fork made by @alt-romes and @mpickering.

cc @csabahruska 